### PR TITLE
Configure default simulation to include 10 nodes

### DIFF
--- a/simulations/omnetpp.ini
+++ b/simulations/omnetpp.ini
@@ -34,18 +34,22 @@ repeat = 30
 **.alohaChannelModel = false
 
 #nodes features
-**.numberOfNodes = 1
+**.numberOfNodes = 10
 **.constraintAreaMaxX = 1000m
 **.constraintAreaMaxY = 1000m
 
-**.loRaNodes[0].**.initialX = 300m
-**.loRaNodes[0].**.initialY = 350m
-**.loRaNodes[0].**initialLoRaSF = 12
-**.loRaNodes[0].**initialLoRaTP = 14dBm
-**.loRaNodes[0].**initialLoRaBW = 125 kHz
-**.loRaNodes[0].**initialLoRaCR = 4
-**.loRaNodes[0].**.initFromDisplayString = false
-**.loRaNodes[0].**.evaluateADRinNode = true
+**.loRaNodes[*].deploymentType = "circle"
+**.loRaNodes[*].maxGatewayDistance = 200m
+**.loRaNodes[*].gatewayX = 200m
+**.loRaNodes[*].gatewayY = 200m
+**.loRaNodes[*].**.initialX = 300m
+**.loRaNodes[*].**.initialY = 350m
+**.loRaNodes[*].**initialLoRaSF = 12
+**.loRaNodes[*].**initialLoRaTP = 14dBm
+**.loRaNodes[*].**initialLoRaBW = 125 kHz
+**.loRaNodes[*].**initialLoRaCR = 4
+**.loRaNodes[*].**.initFromDisplayString = false
+**.loRaNodes[*].**.evaluateADRinNode = true
 **.loRaNodes[*].numApps = 1
 **.loRaNodes[*].app[0].typename = "SimpleLoRaApp"
 


### PR DESCRIPTION
## Summary
- update `omnetpp.ini` to deploy ten LoRa nodes by default
- place nodes randomly around the gateway using the circle deployment

## Testing
- `make makefiles` *(fails: opp_makemake not found)*
- `make` *(fails: checkmakefiles error)*

------
https://chatgpt.com/codex/tasks/task_e_68511839b584832ab55d47d85341c444